### PR TITLE
Expose the PGADMIN_DEFAULT_EMAIL and PGADMIN_DEFAULT_PASSWORD to env variables

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -8,6 +8,10 @@ POSTGRES_PASSWORD=opendatarepository
 POSTGRES_PORT=35432
 TEST_POSTGRES_DB=test_opendatarepository
 
+# PGADMIN
+PGADMIN_DEFAULT_EMAIL=admin@example.com
+PGADMIN_DEFAULT_PASSWORD=admin
+
 ## JWT
 JWT_SECRET=jwtsupersecret
 JWT_ALGORITHM=HS256

--- a/modules/odr_core/odr_core/config.py
+++ b/modules/odr_core/odr_core/config.py
@@ -12,6 +12,10 @@ class Settings(BaseSettings):
     POSTGRES_PASSWORD: str
     POSTGRES_PORT: str
 
+    # PGADMIN
+    PGADMIN_DEFAULT_EMAIL: str
+    PGADMIN_DEFAULT_PASSWORD: str
+
     # Auth - make sure to set this to False in production
     SKIP_AUTH: bool = False
 


### PR DESCRIPTION
Expose the PGADMIN_DEFAULT_EMAIL and PGADMIN_DEFAULT_PASSWORD to env variables so they are easier to find or overwrite.

These otherwise defaulted to values in postgres-compose.yml (https://github.com/Open-Model-Initiative/OMI-Data-Pipeline/blob/main/modules/odr_database/docker/postgres-compose.yml#L19) but although those default values were only used if an env variable was not provided, an env variable was not supported.

I hope this makes it easier to know what these values are as well for people setting up the project locally for the first time.