### PR TITLE
Fix the path to odr_api's main.py in start_server.sh to match run_server.ps1 to fix starting the API on Linux

### DIFF
--- a/modules/odr_api/scripts/start_server.sh
+++ b/modules/odr_api/scripts/start_server.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # Run the FastAPI server with multiple workers and log output to a file
-python modules/odr_api/server/main.py &
+python modules/odr_api/odr_api/main.py &
 echo $! > server.pid


### PR DESCRIPTION
Fix the path to odr_api's main.py in start_server.sh to match run_server.ps1 to fix starting the API on Linux.

Tested on my Linux setup.

See https://github.com/Open-Model-Initiative/OMI-Data-Pipeline/blob/main/modules/odr_api/scripts/run_server.ps1 for comparison..

The main.py file can be found: https://github.com/Open-Model-Initiative/OMI-Data-Pipeline/blob/main/modules/odr_api/odr_api/main.py (see the path)