### PR TITLE
Fix reset-postgres task volume name

### DIFF
--- a/modules/odr_database/Taskfile.yml
+++ b/modules/odr_database/Taskfile.yml
@@ -1,5 +1,10 @@
 # ODR Database Taskfile
 version: '3'
+
+vars:
+  COMPOSE_FILE: ${ROOT_DIR}/modules/odr_database/docker/postgres-compose.yml
+  POSTGRES_VOLUME_NAME: omi-postgres_postgres_data
+
 tasks:
 
 ## PostgreSQL
@@ -15,16 +20,16 @@ tasks:
     desc: Start the postgres database
     cmds:
       - >
-        docker compose -f ${ROOT_DIR}/modules/odr_database/docker/postgres-compose.yml up
+        docker compose -f {{.COMPOSE_FILE}} up
   stop-postgres:
     desc: Stop the postgres database
     cmds:
-      - docker compose -f ${ROOT_DIR}/modules/odr_database/docker/postgres-compose.yml down
+      - docker compose -f {{.COMPOSE_FILE}} down
   rebuild-postgres:
     desc: Rebuild the postgres database
     cmds:
       - >
-        docker compose -f ${ROOT_DIR}/modules/odr_database/docker/postgres-compose.yml up --build
+        docker compose -f {{.COMPOSE_FILE}} up --build
   restart-postgres:
     desc: Restart the postgres database
     deps:
@@ -34,13 +39,13 @@ tasks:
   watch-postgres-logs:
     desc: Watch the postgres logs
     cmds:
-      - docker compose -f ${ROOT_DIR}/modules/odr_database/docker/postgres-compose.yml logs -f
+      - docker compose -f {{.COMPOSE_FILE}} logs -f
 
   reset-postgres:
     desc: Reset the postgres database
     cmds:
-      - docker compose -f ${ROOT_DIR}/modules/odr_database/docker/postgres-compose.yml down
-      - docker volume rm odr_database_postgres_data
+      - docker compose -f {{.COMPOSE_FILE}} down
+      - docker volume rm {{.POSTGRES_VOLUME_NAME}}
       - task: start-postgres
       - task: watch-postgres-logs
 


### PR DESCRIPTION
**Problem Statement**
Fix volume name in reset-postgres task

**Related Issue**
Fixes #17 

**Proposed Changes**

- Added vars section at the top of the taskfile to define COMPOSE_FILE and POSTGRES_VOLUME_NAME variables.
- Updated all docker compose commands to use {{.COMPOSE_FILE}} instead of hardcoding the path.
- In the reset-postgres task, replaced 'odr_database_postgres_data' with {{.POSTGRES_VOLUME_NAME}}.
- Used Task's variable expansion syntax ({{.VAR_NAME}}) throughout the file for consistency and to ensure proper variable expansion.

These changes ensure that the correct volume name (omi-postgres_postgres_data) is used when resetting the Postgres database, resolving the "no such volume" error previously encountered.

**Testing:**
- Verified that all postgres-related tasks work as expected, especially the reset-postgres task.
- Confirmed that the volume is correctly removed and recreated during reset.