### PR TITLE
Add passwordless login to pgadmin and odr database

### DIFF
--- a/modules/odr_database/docker/postgres-compose.yml
+++ b/modules/odr_database/docker/postgres-compose.yml
@@ -6,6 +6,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
@@ -19,6 +20,15 @@ services:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@example.com}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
       PGADMIN_LISTEN_ADDRESS: 0.0.0.0
+      PGADMIN_CONFIG_SERVER_MODE: "False"
+      PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"
+    entrypoint: /bin/sh -c "chmod 600 /pgpass; /entrypoint.sh;"
+    user: root
+    configs:
+      - source: servers.json
+        target: /pgadmin4/servers.json
+      - source: pgpass
+        target: /pgpass
     volumes:
       - pgadmin_data:/var/lib/pgadmin
     ports:
@@ -36,3 +46,19 @@ networks:
   omi-network:
     external: true
     driver: bridge
+
+configs:
+  pgpass:
+    content: postgres:5432:${POSTGRES_DB}:${POSTGRES_USER}:${POSTGRES_PASSWORD}
+  servers.json:
+    content: |
+      {"Servers": {"1": {
+        "Group": "Servers",
+        "Name": "Open Data Repository",
+        "Host": "postgres",
+        "Port": 5432,
+        "MaintenanceDB": "postgres",
+        "Username": "${POSTGRES_USER}",
+        "PassFile": "/pgpass",
+        "SSLMode": "prefer"
+      }}}


### PR DESCRIPTION
Fixes #36 

This pull request enhances the local development experience with pgAdmin by:

- Removing the need for a password
- Automatically connecting to the ODR database

These changes streamline the setup process for developers working on the project locally. Screenshot is attached for reference.

![image](https://github.com/user-attachments/assets/e82d236c-a885-457e-8cc8-e81dab000778)
