### PR TITLE
Update the DCO page to include information on the CDLA 2.0 license.

### DIFF
--- a/modules/odr_frontend/src/routes/dco/+page.svelte
+++ b/modules/odr_frontend/src/routes/dco/+page.svelte
@@ -5,11 +5,17 @@
 </script>
 
 <svelte:head>
-    <title>DCO | OMI Data Pipeline</title>
+    <title>DCO Agreement | OMI Data Pipeline</title>
 </svelte:head>
 
 <div class="flex flex-col overflow-y-auto">
     <main class="container mx-auto p-4">
+        <div class="bg-blue-100 border-l-4 border-blue-500 text-blue-700 p-4 mb-8 rounded-lg">
+            <p>
+                The following Developer Certificate of Origin agreement covers all contributions to Open Model Initiative Datasets. All OMI datasets will fall under the CDLA 2.0 license. See <a href="https://cdla.dev/permissive-2-0/" class="underline" target="_blank" rel="noopener noreferrer">https://cdla.dev/permissive-2-0/</a> for details.
+            </p>
+        </div>
+
         <h1 class="text-3xl font-bold mb-4">Developer Certificate of Origin</h1>
         <h2 class="text-xl mb-2">Version 1.1</h2>
 
@@ -52,9 +58,11 @@ By making a contribution to this project, I certify that:
 
         <form method="POST" use:enhance>
             <div class="mb-4">
-                <label class="flex items-center">
-                    <input type="checkbox" bind:checked={acceptedDCO} name="acceptDCO" class="mr-2">
-                    <span>I accept the terms of the Developer Certificate of Origin</span>
+                <label class="flex items-start">
+                    <input type="checkbox" bind:checked={acceptedDCO} name="acceptDCO" class="mr-3">
+                    <span class="text-sm">
+                        I accept the terms of the Developer Certificate of Origin and the CDLA 2.0 license
+                    </span>
                 </label>
             </div>
             <button


### PR DESCRIPTION
Closes issue #46 

Adds CDLA 2.0 to the DCO page.

### New Screenshots

**Top of page**

![Screenshot 2024-09-20 at 08-32-07 DCO Agreement OMI Data Pipeline](https://github.com/user-attachments/assets/9034ec3b-558a-4331-bafd-996d81a67c89)


**Bottom of page**

![Screenshot 2024-09-20 at 08-32-29 DCO Agreement OMI Data Pipeline](https://github.com/user-attachments/assets/a85887c2-c913-4693-be40-d3781b78fb08)



### Old Screenshots

**Top of page**

![Screenshot 2024-09-20 at 08-36-03 DCO OMI Data Pipeline-main](https://github.com/user-attachments/assets/900d7492-333a-4093-9550-f2162883bb07)


**Bottom of page**

![Screenshot 2024-09-20 at 08-36-16 DCO OMI Data Pipeline-main](https://github.com/user-attachments/assets/80840cb4-a31c-4016-91e1-ae69d05983d9)
