### PR TITLE
add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.1
         with:
-          owner: civitai
-          repo: ansible-omi
+          owner: Open-Model-Initiative
+          repo: data-pipeline-ansible
           workflow_file_name: deploy.yaml
           github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
           ref: main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,4 @@ jobs:
           workflow_file_name: deploy.yaml
           github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
           ref: main
-          client_payload: |
-            { "environment": "${{ github.ref_name == 'release' &&  'prod' || 'dev' }}", "branch": "${{ github.ref_name }}" }
           wait_workflow: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Run Deploy Workflow
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: civitai
+          repo: ansible-omi
+          workflow_file_name: deploy.yaml
+          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
+          ref: main
+          client_payload: |
+            { "environment": "${{ github.ref_name == 'release' &&  'prod' || 'dev' }}", "branch": "${{ github.ref_name }}" }
+          wait_workflow: false


### PR DESCRIPTION
This will trigger the Ansible playbook that I have set up in the `civitai/ansible-omi` repo.

Before this will work, someone needs to add the `GHA_WORKFLOW_TRIGGER` secret. I don't have access to do that, but I can provide the token to someone who does ( @takoyaro perhaps? ).

We can also move the Ansible repo into the OMI organization, if that is desirable.