### PR TITLE
Update checkout action and setup python action versions to remove warnings

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
 


### PR DESCRIPTION
Fixes issue #63 

See https://github.com/actions/setup-python and https://github.com/actions/checkout for reference.

Can see newer check without warnings here: https://github.com/Open-Model-Initiative/OMI-Data-Pipeline/actions/runs/11187935564

And older check with warnings here: https://github.com/Open-Model-Initiative/OMI-Data-Pipeline/actions/runs/10992961609