### PR TITLE
Upgrade postgresql 17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 name: omi-postgres
 services:
   postgres:
-    image: pgvector/pgvector:pg16
+    image: pgvector/pgvector:pg17
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}


### PR DESCRIPTION
### Problem Statement: 
PostgreSQL 17 has been released with performance improvements. The project currently uses an outdated version (PostgreSQL 16), and upgrading will provide better performance, scalability, and long-term support.

### Related Issues:
- Fixes #61 

### Proposed Changes:
- Upgraded the PostgreSQL image from pgvector/pgvector:pg16 to pgvector/pgvector:pg17 in the docker-compose.yml file
