### PR TITLE
Initial work to run Playwright as a GitHub action on our new end to end setup

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -104,5 +104,5 @@ jobs:
         if: always()
         with:
           name: playwright-report
-          path: playwright-report/
+          path: modules/odr_frontend/playwright-report/
           retention-days: 7

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,9 +17,16 @@ jobs:
         with:
           node-version: lts/*
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: |
+          npm install -g pnpm
+          pnpm install
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       # - name: Run Playwright tests
       #   run: pnpm exec playwright test
       - name: Run Playwright tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,7 +1,5 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [ main, 80-update-playwright-setup ]
   pull_request:
     branches: [ main ]
 jobs:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,6 +23,7 @@ jobs:
       # - name: Run Playwright tests
       #   run: pnpm exec playwright test
       - name: Run Playwright tests
+        working-directory: .
         run: |
           chmod +x run-playwright.sh
           ./run-playwright.sh
@@ -30,5 +31,5 @@ jobs:
         if: always()
         with:
           name: playwright-report
-          path: modules/odr_frontend/playwright-report/
+          path: playwright-report/
           retention-days: 7

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -37,6 +37,18 @@ jobs:
           POSTGRES_PORT=35432
           PGADMIN_DEFAULT_EMAIL=pipeline@example.com
           PGADMIN_DEFAULT_PASSWORD=pipeline
+          POSTGRES_HOST=localhost
+          TEST_POSTGRES_DB=test_opendatarepository
+          JWT_SECRET=pipelinesecret
+          JWT_ALGORITHM=HS256
+          JWT_EXPIRATION_SECONDS=3600
+          SESSION_MAX_AGE_SECONDS=4233600
+          DEFAULT_SUPERUSER_EMAIL=pipeline@opendatarepository.com
+          DEFAULT_SUPERUSER_PASSWORD=pipeline
+          DEFAULT_SUPERUSER_USERNAME=pipeline
+          OAUTH2_REDIRECT_PATH=docs
+          HF_TOKEN=pipeline_token
+          HF_HDR_DATASET_NAME=openmodelinitiative/pipeline-hdr-submissions
           EOF
       - name: Create temp frontend .env file
         run: |
@@ -48,6 +60,14 @@ jobs:
           POSTGRES_PORT=35432
           PGADMIN_DEFAULT_EMAIL=pipeline@example.com
           PGADMIN_DEFAULT_PASSWORD=pipeline
+          PUBLIC_API_BASE_URL=http://localhost:31100
+          API_SERVICE_URL=http://odr-api:31100
+          GOOGLE_CLIENT_ID=google_client_id
+          GOOGLE_CLIENT_SECRET=google_client_secret
+          GITHUB_CLIENT_ID=github_client_id
+          GITHUB_CLIENT_SECRET=github_client_secret
+          DISCORD_CLIENT_ID=discord_client_id
+          DISCORD_CLIENT_SECRET=discord_client_secret
           EOF
       - name: Create Docker network
         run: docker network inspect omi-network >/dev/null 2>&1 || docker network create omi-network

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,6 +31,9 @@ jobs:
         working-directory: .
         run: |
           cat << EOF > .env
+          ROOT_DIR=.
+          MODEL_CACHE_DIR=
+
           POSTGRES_HOST=localhost
           POSTGRES_DB=odr_pipeline
           POSTGRES_USER=odr_pipeline

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     timeout-minutes: 10
+    continue-on-error: true # For now, until things are more stable.
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,43 +31,63 @@ jobs:
         working-directory: .
         run: |
           cat << EOF > .env
+          POSTGRES_HOST=localhost
           POSTGRES_DB=odr_pipeline
           POSTGRES_USER=odr_pipeline
           POSTGRES_PASSWORD=odr_pipeline
           POSTGRES_PORT=35432
+          TEST_POSTGRES_DB=test_odr_pipeline
+
           PGADMIN_DEFAULT_EMAIL=pipeline@example.com
           PGADMIN_DEFAULT_PASSWORD=pipeline
-          POSTGRES_HOST=localhost
-          TEST_POSTGRES_DB=test_opendatarepository
+
           JWT_SECRET=pipelinesecret
           JWT_ALGORITHM=HS256
           JWT_EXPIRATION_SECONDS=3600
+
           SESSION_MAX_AGE_SECONDS=4233600
+
           DEFAULT_SUPERUSER_EMAIL=pipeline@opendatarepository.com
           DEFAULT_SUPERUSER_PASSWORD=pipeline
           DEFAULT_SUPERUSER_USERNAME=pipeline
+
+          GOOGLE_CLIENT_ID=google_client_id
+          GOOGLE_CLIENT_SECRET=google_client_secret
+
+          GITHUB_CLIENT_ID=github_client_id
+          GITHUB_CLIENT_SECRET=github_client_secret
+
+          DISCORD_CLIENT_ID=discord_client_id
+          DISCORD_CLIENT_SECRET=discord_client_secret
+
           OAUTH2_REDIRECT_PATH=docs
+
           HF_TOKEN=pipeline_token
           HF_HDR_DATASET_NAME=openmodelinitiative/pipeline-hdr-submissions
           EOF
       - name: Create temp frontend .env file
         run: |
           cat << EOF > .env
+          PUBLIC_API_BASE_URL=http://localhost:31100
+          API_SERVICE_URL=http://odr-api:31100
+
           AUTH_SECRET=authpipeline
+
+          GOOGLE_CLIENT_ID=google_client_id
+          GOOGLE_CLIENT_SECRET=google_client_secret
+
+          GITHUB_CLIENT_ID=github_client_id
+          GITHUB_CLIENT_SECRET=github_client_secret
+
+          DISCORD_CLIENT_ID=discord_client_id
+          DISCORD_CLIENT_SECRET=discord_client_secret
+
+          POSTGRES_HOST=postgres
           POSTGRES_DB=odr_pipeline
           POSTGRES_USER=odr_pipeline
           POSTGRES_PASSWORD=odr_pipeline
-          POSTGRES_PORT=35432
-          PGADMIN_DEFAULT_EMAIL=pipeline@example.com
-          PGADMIN_DEFAULT_PASSWORD=pipeline
-          PUBLIC_API_BASE_URL=http://localhost:31100
-          API_SERVICE_URL=http://odr-api:31100
-          GOOGLE_CLIENT_ID=google_client_id
-          GOOGLE_CLIENT_SECRET=google_client_secret
-          GITHUB_CLIENT_ID=github_client_id
-          GITHUB_CLIENT_SECRET=github_client_secret
-          DISCORD_CLIENT_ID=discord_client_id
-          DISCORD_CLIENT_SECRET=discord_client_secret
+          POSTGRES_PORT=5432
+          TEST_POSTGRES_DB=test_odr_pipeline
           EOF
       - name: Create Docker network
         run: docker network inspect omi-network >/dev/null 2>&1 || docker network create omi-network

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,13 +1,16 @@
 name: Playwright Tests
 on:
   push:
-    branches: [main, master]
+    branches: [ main, 80-update-playwright-setup ]
   pull_request:
-    branches: [main, master]
+    branches: [ main ]
 jobs:
   test:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: modules/odr_frontend
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -17,11 +20,15 @@ jobs:
         run: npm install -g pnpm && pnpm install
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
+      # - name: Run Playwright tests
+      #   run: pnpm exec playwright test
       - name: Run Playwright tests
-        run: pnpm exec playwright test
+        run: |
+          chmod +x run-playwright.sh
+          ./run-playwright.sh
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report
-          path: playwright-report/
+          path: modules/odr_frontend/playwright-report/
           retention-days: 7

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,8 +27,28 @@ jobs:
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Run Playwright tests
-      #   run: pnpm exec playwright test
+      - name: Create temp root .env file
+        working-directory: .
+        run: |
+          cat << EOF > .env
+          POSTGRES_DB=odr_pipeline
+          POSTGRES_USER=odr_pipeline
+          POSTGRES_PASSWORD=odr_pipeline
+          POSTGRES_PORT=35432
+          PGADMIN_DEFAULT_EMAIL=pipeline@example.com
+          PGADMIN_DEFAULT_PASSWORD=pipeline
+          EOF
+      - name: Create temp frontend .env file
+        run: |
+          cat << EOF > .env
+          AUTH_SECRET=authpipeline
+          POSTGRES_DB=odr_pipeline
+          POSTGRES_USER=odr_pipeline
+          POSTGRES_PASSWORD=odr_pipeline
+          POSTGRES_PORT=35432
+          PGADMIN_DEFAULT_EMAIL=pipeline@example.com
+          PGADMIN_DEFAULT_PASSWORD=pipeline
+          EOF
       - name: Run Playwright tests
         working-directory: .
         run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,6 +49,8 @@ jobs:
           PGADMIN_DEFAULT_EMAIL=pipeline@example.com
           PGADMIN_DEFAULT_PASSWORD=pipeline
           EOF
+      - name: Create Docker network
+        run: docker network inspect omi-network >/dev/null 2>&1 || docker network create omi-network
       - name: Run Playwright tests
         working-directory: .
         run: |

--- a/modules/odr_frontend/playwright.config.ts
+++ b/modules/odr_frontend/playwright.config.ts
@@ -1,15 +1,15 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
-	webServer: {
-		command: 'npm run build && npm run preview',
-		port: 4173
-	},
+	// webServer: {
+	// 	command: 'npm run build && npm run preview',
+	// 	port: 4173
+	// },
 	testDir: 'tests',
 	testMatch: /(.+\.)?(test|spec)\.[jt]s/,
 	use: {
-		baseURL: 'http://localhost:4173'
-		// headless: false
+		baseURL: 'http://localhost:5173',
+		headless: false
 	}
 };
 

--- a/modules/odr_frontend/playwright.config.ts
+++ b/modules/odr_frontend/playwright.config.ts
@@ -5,7 +5,7 @@ const config: PlaywrightTestConfig = {
 	testMatch: /(.+\.)?(test|spec)\.[jt]s/,
 	use: {
 		baseURL: 'http://localhost:5173',
-		headless: false
+		headless: true
 	}
 };
 

--- a/modules/odr_frontend/playwright.config.ts
+++ b/modules/odr_frontend/playwright.config.ts
@@ -1,10 +1,6 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
-	// webServer: {
-	// 	command: 'npm run build && npm run preview',
-	// 	port: 4173
-	// },
 	testDir: 'tests',
 	testMatch: /(.+\.)?(test|spec)\.[jt]s/,
 	use: {

--- a/modules/odr_frontend/playwright.config.ts
+++ b/modules/odr_frontend/playwright.config.ts
@@ -2,11 +2,16 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
 	testDir: 'tests',
+	forbidOnly: !!process.env.CI,
 	testMatch: /(.+\.)?(test|spec)\.[jt]s/,
 	use: {
 		baseURL: 'http://localhost:5173',
 		headless: true
-	}
+	},
+	reporter: [
+        ['html', { outputFolder: 'playwright-report' }],
+        ['list']
+    ]
 };
 
 export default config;

--- a/modules/odr_frontend/tests/test.ts
+++ b/modules/odr_frontend/tests/test.ts
@@ -1,6 +1,56 @@
 import { expect, test } from '@playwright/test';
 
-test('home page has expected title', async ({ page }) => {
+test('Auth page has expected home link', async ({ page }) => {
 	await page.goto('/');
-	await expect(page.getByRole('heading', { name: 'Authenticate.' })).toBeVisible();
+	await expect(page.getByRole('link', { name: 'OMI DATA PIPELINE' })).toBeVisible();
+});
+
+test('Auth page has expected sign in options', async ({ page }) => {
+	await page.goto('/');
+	await expect(page.getByTestId('app-bar').getByRole('button', { name: 'GitHub' })).toBeVisible();
+	await expect(page.getByTestId('app-bar').getByRole('button', { name: 'Discord' })).toBeVisible();
+
+	await expect(page.getByRole('button', { name: 'Sign In with GitHub' })).toBeVisible();
+	await expect(page.getByRole('button', { name: 'Sign In with Discord' })).toBeVisible();
+});
+
+test('Auth page has expected footer links', async ({ page }) => {
+	await page.goto('/');
+
+	// TODO: Update footer icons to have better user accessible locators.
+	// Get all links
+	const links = page.getByRole('link');
+
+	// Check the first link (index 1)
+	const firstLink = links.nth(1);
+	await expect(firstLink).toBeVisible();
+	expect(await firstLink.getAttribute('href')).toBe('https://discord.gg/swYY5RVHft');
+
+	// Check the second link (index 2)
+	const secondLink = links.nth(2);
+	await expect(secondLink).toBeVisible();
+	expect(await secondLink.getAttribute('href')).toBe('https://github.com/Open-Model-Initiative/OMI-Data-Pipeline');
+});
+
+test('Unauthenticated user is redirect to auth page', async ({ page }) => {
+	await page.goto('/admin');
+	await expect(page).toHaveURL('/auth');
+
+	await page.goto('/datasets');
+	await expect(page).toHaveURL('/auth');
+
+	await page.goto('/dco');
+	await expect(page).toHaveURL('/auth');
+
+	await page.goto('/dump');
+	await expect(page).toHaveURL('/auth');
+
+	// await page.goto('/inactive');
+	// await expect(page).toHaveURL('/auth');
+
+	await page.goto('/queue');
+	await expect(page).toHaveURL('/auth');
+
+	await page.goto('/reports');
+	await expect(page).toHaveURL('/auth');
 });

--- a/run-playwright.sh
+++ b/run-playwright.sh
@@ -3,7 +3,28 @@ set -e
 
 task dev &
 echo "Waiting for services to start..."
-sleep 300
+
+# Maximum wait time in seconds
+max_wait=300
+check_interval=5
+start_time=$(date +%s)
+
+while true; do
+    if docker compose logs | grep -q "INFO:     Application startup complete."; then
+        echo "Services started successfully."
+        break
+    fi
+
+    current_time=$(date +%s)
+    elapsed=$((current_time - start_time))
+
+    if [ $elapsed -ge $max_wait ]; then
+        echo "Timeout: Services did not start within $max_wait seconds."
+        exit 1
+    fi
+
+    sleep $check_interval
+done
 
 cd modules/odr_frontend
 npx playwright test

--- a/run-playwright.sh
+++ b/run-playwright.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+task dev &
+echo "Waiting for services to start..."
+sleep 300
+
+cd modules/odr_frontend
+npx playwright test
+
+cd ../..
+docker compose down


### PR DESCRIPTION
Closes #80 

Sets up a bare minimum run of Playwright in the pipeline. Switches from trying to run the front end on its own to testing a full end to end environment/setup. 

It is set to non-blocking for now until things are more settled.

Currently only capable of running unauthenticated checks.
Will need further work to support authenticated actions in the future (likely via some sort of default bot token, or env variable which can be set in the header to act as a mocked user or such)

Adds some more basic configuration including reporters and the forbidOnly safety check for pipelines.

Updates the initial test to match the current setup and adds a few more basic tests (which can be further improved in future work)

Also adds a helper script which kicks off our `task dev` and then runs Playwright once the environment is ready, used for the pipeline mainly works locally too.

Example run can be seen here: https://github.com/Open-Model-Initiative/OMI-Data-Pipeline/actions/runs/11195926446

And locally as well: 

![image](https://github.com/user-attachments/assets/55993041-183b-4c8b-a9c9-a04bb407df93)
