### PR TITLE
Ensure the teams page auto updates for new teams or users added to a team

### DIFF
--- a/modules/odr_frontend/src/routes/admin/+page.svelte
+++ b/modules/odr_frontend/src/routes/admin/+page.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <svelte:head>
-	<title>OMI Data Pipeline| Admin</title>
+	<title>Admin | OMI Data Pipeline</title>
 </svelte:head>
 
 <code>

--- a/modules/odr_frontend/src/routes/admin/teams/api/+server.ts
+++ b/modules/odr_frontend/src/routes/admin/teams/api/+server.ts
@@ -1,16 +1,33 @@
 import { pgClient } from '$lib/server/pg';
 import type { RequestHandler } from '@sveltejs/kit';
+
 export const POST: RequestHandler = async ({ request }) => {
-	const body = await request.json();
-	if (!body.newTeamName) {
-		return new Response(JSON.stringify({ success: false, error: 'No Team name provided' }));
-	}
-	try {
-		const result = await pgClient.query('INSERT INTO teams (name) VALUES ($1)', [body.newTeamName]);
-		console.info(`Added team ${body.newTeamName}`);
-		return new Response(JSON.stringify({ success: true, result: result }));
-	} catch (e) {
-		console.error(`Failed to add team ${body.newTeamName}`);
-		return new Response(JSON.stringify({ success: false, error: e }));
-	}
+    const body = await request.json();
+    if (!body.newTeamName) {
+        return new Response(JSON.stringify({ success: false, error: 'No Team name provided' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    }
+
+    try {
+        const result = await pgClient.query(
+            'INSERT INTO teams (name) VALUES ($1) RETURNING id, name, created_at, updated_at',
+            [body.newTeamName]
+        );
+
+        const newTeam = result.rows[0];
+        console.info(`Added team ${body.newTeamName} with id ${newTeam.id}`);
+
+        return new Response(JSON.stringify({ success: true, team: newTeam }), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    } catch (e) {
+        console.error(`Failed to add team ${body.newTeamName}:`, e);
+        return new Response(JSON.stringify({ success: false, error: e.message }), {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    }
 };

--- a/modules/odr_frontend/src/routes/admin/teams/api/addUser/+server.ts
+++ b/modules/odr_frontend/src/routes/admin/teams/api/addUser/+server.ts
@@ -1,28 +1,44 @@
 import { PG_API, pgClient } from '$lib/server/pg';
 import type { RequestHandler } from '@sveltejs/kit';
+
 export const POST: RequestHandler = async ({ request }) => {
-	const body = await request.json();
-	if (!body.userId) {
-		return new Response(JSON.stringify({ success: false, error: 'No user ID provided' }));
-	}
-	if (!body.teamId) {
-		return new Response(JSON.stringify({ success: false, error: 'No team ID provided' }));
-	}
+    const body = await request.json();
+    if (!body.userId) {
+        return new Response(JSON.stringify({ success: false, error: 'No user ID provided' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    }
+    if (!body.teamId) {
+        return new Response(JSON.stringify({ success: false, error: 'No team ID provided' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    }
 
-	const team_users = await PG_API.teams.getUsers(body.teamId);
-	if (team_users.some((user) => user.user_id == body.userId)) {
-		return new Response(JSON.stringify({ success: false, error: 'User already in team' }));
-	}
+    const team_users = await PG_API.teams.getUsers(body.teamId);
+    if (team_users.some((user) => user.user_id == body.userId)) {
+        return new Response(JSON.stringify({ success: false, error: 'User already in team' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    }
 
-	try {
-		const result = await pgClient.query(
-			'INSERT INTO user_teams (team_id, user_id, role) VALUES ($1, $2, $3)',
-			[body.teamId, body.userId, 'member']
-		);
-		console.info(`Added user ${body.userId} to team ${body.teamId}`);
-		return new Response(JSON.stringify({ success: true, result: result }));
-	} catch (e) {
-		console.error(`Failed to add user ${body.userId} to team ${body.teamId}`);
-		return new Response(JSON.stringify({ success: false, error: e }));
-	}
+    try {
+        const result = await pgClient.query(
+            'INSERT INTO user_teams (team_id, user_id, role) VALUES ($1, $2, $3) RETURNING *',
+            [body.teamId, body.userId, 'member']
+        );
+        console.info(`Added user ${body.userId} to team ${body.teamId}`);
+        return new Response(JSON.stringify({ success: true, team_user: result.rows[0] }), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    } catch (e) {
+        console.error(`Failed to add user ${body.userId} to team ${body.teamId}:`, e);
+        return new Response(JSON.stringify({ success: false, error: e.message }), {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    }
 };


### PR DESCRIPTION
Closes #68 

Ensures that when a new team is added to the teams page, the table automatically updates to show it, and clears out the entered team name field.

Also did the same for adding a user to a team for a smoother experience there as well.

Also the admin page title was in the reverse order of other pages, so I aligned that as well.