### PR TITLE
Update the frontend install to also setup Playwright browsers

### DIFF
--- a/modules/odr_frontend/Taskfile.yml
+++ b/modules/odr_frontend/Taskfile.yml
@@ -4,8 +4,10 @@ version: 3
 tasks:
   install:
     desc: Install npm dependencies
+    dir: '{{.ROOT_DIR}}/modules/odr_frontend'
     cmds:
-      - pnpm -C {{.ROOT_DIR}}/modules/odr_frontend install
+      - pnpm install
+      - pnpm exec playwright install
   test:
     desc: Run unit and integration tests
     cmds:


### PR DESCRIPTION
Closes #85 

Add Playwright browser setup to the frontend install task to allow for a smoother developer setup experience.