### PR TITLE
Disallow duplicate team names and trim leading/trailing spaces

### DIFF
--- a/modules/odr_core/odr_core/models/team.py
+++ b/modules/odr_core/odr_core/models/team.py
@@ -8,7 +8,7 @@ class Team(Base):
     __tablename__ = "teams"
 
     id = Column(Integer, primary_key=True, index=True)
-    name = Column(String, index=True)
+    name = Column(String, index=True, unique=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 

--- a/modules/odr_datamodel/alembic/versions/31ba65eb76f9_make_team_names_unique.py
+++ b/modules/odr_datamodel/alembic/versions/31ba65eb76f9_make_team_names_unique.py
@@ -1,0 +1,26 @@
+"""'Make team names unique'
+
+Revision ID: 31ba65eb76f9
+Revises: 2f2d84a873f5
+Create Date: 2024-10-11 22:11:44.302197
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '31ba65eb76f9'
+down_revision: Union[str, None] = '2f2d84a873f5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint('unique_team_name', 'teams', ['name'])
+
+
+def downgrade() -> None:
+    op.drop_constraint('unique_team_name', 'teams', type_='unique')

--- a/modules/odr_frontend/src/routes/admin/teams/+page.svelte
+++ b/modules/odr_frontend/src/routes/admin/teams/+page.svelte
@@ -33,6 +33,7 @@
 			teams = [...teams, newTeam];
 			newTeamName = '';
 		} else {
+			alert(res.error); // TODO: Use Toast notification later
 			console.error(res.error);
 		}
 	}

--- a/modules/odr_frontend/src/routes/admin/teams/api/+server.ts
+++ b/modules/odr_frontend/src/routes/admin/teams/api/+server.ts
@@ -3,7 +3,9 @@ import type { RequestHandler } from '@sveltejs/kit';
 
 export const POST: RequestHandler = async ({ request }) => {
     const body = await request.json();
-    if (!body.newTeamName) {
+    const trimmedTeamName = body.newTeamName?.trim();
+
+    if (!trimmedTeamName) {
         return new Response(JSON.stringify({ success: false, error: 'No Team name provided' }), {
             status: 400,
             headers: { 'Content-Type': 'application/json' }
@@ -13,19 +15,26 @@ export const POST: RequestHandler = async ({ request }) => {
     try {
         const result = await pgClient.query(
             'INSERT INTO teams (name) VALUES ($1) RETURNING id, name, created_at, updated_at',
-            [body.newTeamName]
+            [trimmedTeamName]
         );
-
         const newTeam = result.rows[0];
-        console.info(`Added team ${body.newTeamName} with id ${newTeam.id}`);
-
+        console.info(`Added team ${trimmedTeamName} with id ${newTeam.id}`);
         return new Response(JSON.stringify({ success: true, team: newTeam }), {
             status: 201,
             headers: { 'Content-Type': 'application/json' }
         });
     } catch (e) {
-        console.error(`Failed to add team ${body.newTeamName}:`, e);
-        return new Response(JSON.stringify({ success: false, error: e.message }), {
+        console.error(`Failed to add team ${trimmedTeamName}:`, e);
+
+        // Type assertion for TypeScript
+        if ((e as { code?: string }).code === '23505') {  // PostgreSQL error code for unique constraint violation
+            return new Response(JSON.stringify({ success: false, error: 'Team name already exists' }), {
+                status: 400,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
+
+        return new Response(JSON.stringify({ success: false, error: 'An unexpected error occurred' }), {
             status: 500,
             headers: { 'Content-Type': 'application/json' }
         });


### PR DESCRIPTION
Closes #69 

Stops allowing duplicate team names and trims team name whitespace.