### PR TITLE
Fix issue of additional "contentAuthors" property on ContentBase schema

### DIFF
--- a/modules/odr_core/odr_core/schemas/content.py
+++ b/modules/odr_core/odr_core/schemas/content.py
@@ -67,7 +67,7 @@ class ContentBase(BaseModel):
     license_url: Optional[HttpUrl] = None
     flags: int = 0
     meta: Optional[dict] = None
-    contentAuthors: List[ContentAuthor] = []
+    content_authors: List[ContentAuthor] = []
     sources: List[ContentSource] = []
 
 


### PR DESCRIPTION
Closes #123 

Additional contentAuthors no longer appears in the endpoint example:
![image](https://github.com/user-attachments/assets/ad19ceeb-a78b-4a5d-891e-8698eea064ef)

And was able to successfully create a content entry with the endpoint still.