### PR TITLE
Add the initial suspected illegal content button to flag concerning content for further review

### DIFF
--- a/modules/odr_frontend/package.json
+++ b/modules/odr_frontend/package.json
@@ -56,6 +56,7 @@
 		"highlight.js": "11.10.0",
 		"next-auth": "^4.24.11",
 		"pg": "^8.13.1",
-		"pnpm": "^9.15.3"
+		"pnpm": "^9.15.3",
+		"svelte-awesome-icons": "^1.2.1"
 	}
 }

--- a/modules/odr_frontend/pnpm-lock.yaml
+++ b/modules/odr_frontend/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       pnpm:
         specifier: ^9.15.3
         version: 9.15.3
+      svelte-awesome-icons:
+        specifier: ^1.2.1
+        version: 1.2.1(svelte@4.2.19)
     devDependencies:
       '@playwright/test':
         specifier: 1.46.0
@@ -2575,6 +2578,11 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svelte-awesome-icons@1.2.1:
+    resolution: {integrity: sha512-vCWzD3bOpQnkx3kMc8D5/+zeOcIvRUO1eI3OT1RmNpPbRimpUwlb/9sVx9CD+m4UjvdkdVHZfSYgTXGiUMH0kA==}
+    peerDependencies:
+      svelte: ^3.54.0 || ^4.0.0 || ^5.0.0
 
   svelte-check@3.8.6:
     resolution: {integrity: sha512-ij0u4Lw/sOTREP13BdWZjiXD/BlHE6/e2e34XzmVmsp5IN4kVa3PWP65NM32JAgwjZlwBg/+JtiNV1MM8khu0Q==}
@@ -5639,6 +5647,10 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svelte-awesome-icons@1.2.1(svelte@4.2.19):
+    dependencies:
+      svelte: 4.2.19
 
   svelte-check@3.8.6(postcss-load-config@4.0.2(postcss@8.4.41))(postcss@8.4.41)(svelte@4.2.19):
     dependencies:

--- a/modules/odr_frontend/src/routes/+page.server.ts
+++ b/modules/odr_frontend/src/routes/+page.server.ts
@@ -26,6 +26,7 @@ const UPLOAD_DIR = process.env.UPLOAD_DIR || './uploads';
 const PENDING_DIR = join(UPLOAD_DIR, 'pending');
 const ACCEPTED_DIR = join(UPLOAD_DIR, 'accepted');
 const REJECTED_DIR = join(UPLOAD_DIR, 'rejected');
+const FLAGGED_DIR = join(UPLOAD_DIR, 'flagged');
 const API_BASE_URL = process.env.API_SERVICE_URL || 'http://odr-api:31100/api/v1';
 
 let s3Client: S3Client | null = null;
@@ -118,6 +119,8 @@ export const actions = {
 			await mkdir(PENDING_DIR, { recursive: true });
 			await mkdir(ACCEPTED_DIR, { recursive: true });
 			await mkdir(REJECTED_DIR, { recursive: true });
+			await mkdir(FLAGGED_DIR, { recursive: true });
+
 
 			if (process.env.NODE_ENV === 'production') {
 			  	// S3 upload for production
@@ -147,10 +150,10 @@ export const actions = {
 			} else {
 				// Local file system for development
 				const cleanedFilePath = join(PENDING_DIR, uniqueFileName);
-				await writeFile(cleanedFilePath, cleanedBuffer);
+				await writeFile(cleanedFilePath, new Uint8Array(cleanedBuffer));
 
 				const jpgFilePath = join(PENDING_DIR, jpgFileName);
-				await writeFile(jpgFilePath, jpgBuffer);
+				await writeFile(jpgFilePath, new Uint8Array(jpgBuffer));
 
 				const metadataFilePath = join(PENDING_DIR, metadataFileName);
 				await writeFile(metadataFilePath, metadataContent);

--- a/modules/odr_frontend/src/routes/admin/moderation/+page.svelte
+++ b/modules/odr_frontend/src/routes/admin/moderation/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+	import { getToastStore } from '@skeletonlabs/skeleton';
 	import './moderation.css';
 	import { goto } from '$app/navigation';
 	import { TriangleExclamationSolid } from 'svelte-awesome-icons';
 	import type { PageData } from './$types';
+	import { MakeToastMessage } from '$lib/toastHelper';
+
+	const toastStore = getToastStore();
 
 	export let data: PageData;
 
@@ -24,8 +28,10 @@
 		if (response.ok) {
 			// Remove the image from the list
 			images = images.filter(img => img.filename !== filename);
+			toastStore.trigger(MakeToastMessage(`Image ${action}ed successfully.`, 'success'));
 		} else {
 			console.error(`Failed to ${action} image`);
+			toastStore.trigger(MakeToastMessage(`Failed to ${action} image`, 'error'));
 		}
 	}
 
@@ -74,26 +80,30 @@
 			  <pre>{JSON.stringify(image.metadata, null, 2)}</pre>
 			</td>
 			<td>
-				<button
+				<div class="button-group">
+				  <button
 					class="btn btn-sm variant-filled-success"
 					on:click={() => handleAction('accept', image.filename)}
-				>
-				Accept
-			  </button>
-			  <button
-				class="btn btn-sm variant-filled-error"
-				on:click={() => handleAction('reject', image.filename)}
-			  >
-				Reject
-			  </button>
-			  <button
-				class="btn btn-sm variant-filled-warning"
-				on:click={() => handleAction('flag', image.filename)}
-				title="Flag suspected illegal content"
-			  >
-				<TriangleExclamationSolid size="20" />
-			  </button>
-			</td>
+					title="Accept the image"
+				  >
+					Accept
+				  </button>
+				  <button
+					class="btn btn-sm variant-filled-error"
+					on:click={() => handleAction('reject', image.filename)}
+					title="Reject the image"
+				  >
+					Reject
+				  </button>
+				  <button
+					class="btn btn-sm variant-filled-warning flag-button"
+					on:click={() => handleAction('flag', image.filename)}
+					title="Flag suspected illegal content"
+				  >
+					<TriangleExclamationSolid size="23" />
+				  </button>
+				</div>
+			  </td>
 		  </tr>
 		{/each}
 	  </tbody>

--- a/modules/odr_frontend/src/routes/admin/moderation/+page.svelte
+++ b/modules/odr_frontend/src/routes/admin/moderation/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import './moderation.css';
 	import { goto } from '$app/navigation';
+	import { TriangleExclamationSolid } from 'svelte-awesome-icons';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
@@ -11,7 +12,7 @@
 		goto(`?page=${page}`);
 	}
 
-	async function handleAction(action: 'accept' | 'reject', filename: string) {
+	async function handleAction(action: 'accept' | 'reject' | 'flag', filename: string) {
 		const form = new FormData();
 		form.append('filename', filename);
 
@@ -84,6 +85,13 @@
 				on:click={() => handleAction('reject', image.filename)}
 			  >
 				Reject
+			  </button>
+			  <button
+				class="btn btn-sm variant-filled-warning"
+				on:click={() => handleAction('flag', image.filename)}
+				title="Flag suspected illegal content"
+			  >
+				<TriangleExclamationSolid size="20" />
 			  </button>
 			</td>
 		  </tr>

--- a/modules/odr_frontend/src/routes/admin/moderation/moderation.css
+++ b/modules/odr_frontend/src/routes/admin/moderation/moderation.css
@@ -88,3 +88,12 @@
   h1 {
     padding: 0 0 1rem 0;
   }
+
+  .variant-filled-warning {
+    background-color: #ffc107;
+    color: #000;
+  }
+
+  .variant-filled-warning:hover {
+    background-color: #e0a800;
+  }

--- a/modules/odr_frontend/src/routes/admin/moderation/moderation.css
+++ b/modules/odr_frontend/src/routes/admin/moderation/moderation.css
@@ -97,3 +97,21 @@
   .variant-filled-warning:hover {
     background-color: #e0a800;
   }
+
+  .button-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .flag-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem;
+    height: 100%;
+  }
+
+  .flag-button :global(svg) {
+    display: block;
+  }


### PR DESCRIPTION
Closes #145 

Initial work to add the new button to flag content as potentially illegal, separate from the regular rejection process:

![image](https://github.com/user-attachments/assets/044e5ed7-12e0-4761-9bc1-edd4cabd4f1e)

Note this PR also adds our Toast support for the image moderation process to show image moderation success/failure:

![image](https://github.com/user-attachments/assets/66aa8f0b-7bd9-4da8-83b9-a4645f7cb03b)



Future work will be needed to complete this process end to end such as #147 
