### PR TITLE
Add doc job, and builders

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# .github/workflows/documentation.yml
+# -----------------------------------------------------------------------------
+
+name: documentation
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main", "doc_sandbox"]
+    paths:
+      - 'doc/**'
+      - '.github/workflows/documentation.yml'
+
+permissions:
+    pages: write
+    contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: Install dependencies
+        run: |
+          pip install sphinx pydata-sphinx-theme myst_parser
+      - name: Sphinx build
+        run: |
+          sphinx-build doc _build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/doc_sandbox') }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          force_orphan: true

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,19 @@
+# Open Model Initiative Data Repository Documentation Makefile
+#
+# This minimal makefile is used to build the Open Model Initiative Data Repository documentation with Sphinx.
+# You can set or override the following variables from the command line or the environment:
+#   SPHINXOPTS, SPHINXBUILD, etc.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without an argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using "make mode".
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,34 @@
+# doc/conf.py
+# -----------------------------------------------------------------------------
+# Configuration file for the Sphinx documentation builder.
+# For the full list of built-in configuration values, see:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+#
+# SPDX-License-Identifier: Apache-2.0
+# graphcap.module.doc.conf.py
+# -----------------------------------------------------------------------------
+
+# -- Project information -----------------------------------------------------
+project = "Open Model Intitiative - Data Repository"
+copyright = "2025, Open Model Intitiative Contributors"
+author = "Open Model Intitiative"
+release = "0.1"
+
+# -- General configuration ---------------------------------------------------
+extensions = ["myst_parser"]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- Options for HTML output -------------------------------------------------
+# Update the theme to use pydata-sphinx-theme
+html_theme = "pydata_sphinx_theme"
+
+# Optional: Add pydata-sphinx-theme specific options
+html_theme_options = {
+    "navbar_start": ["navbar-logo"],
+    "navbar_end": ["navbar-icon-links"],
+    # Add additional customization options here as needed.
+}
+
+html_static_path = ["_static"]

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,50 @@
+# Open Model Initiative - Data Pipeline
+
+========================================
+
+.. |OpenSSF Best Practices| image:: https://www.bestpractices.dev/projects/9549/badge
+   :target: https://www.bestpractices.dev/projects/9549
+.. |License| image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg
+   :target: LICENSE
+
+Welcome to the Open Model Initiative Data Pipeline repository!
+
+This project aims to provide open-source, community-driven training pipelines and code for developing baseline AI models for image generation. Other modalities may be released in future updates, whether in this repo or others.
+
+About the Project
+-----------------
+
+The Open Model Initiative Data Pipeline is a collaborative effort to create and maintain high-quality, openly licensed baseline AI models, and provide tooling to maintain and curate datasets for large training projects. Our goal is to empower individuals and organizations to leverage and build upon these models for their own solutions, and to allow creatives the capacity to utilize these emerging tools for their own creative pursuits.
+
+Key goals:
+----------
+
+- Effective captioning management and curation tools for large datasets
+- Standardized metadata format for utilizing datasets across applications
+- Comprehensive documentation and examples
+
+Contributing
+------------
+
+We welcome contributions from the community! Whether you're fixing bugs, improving documentation, or proposing new features, your input is valuable. Please read our `Contribution <CONTRIBUTING.md>`_ Guidelines and our `Getting Started Guide <GETTING_STARTED.md>`_ for more information on how to get started.
+
+License
+-------
+
+This project and its artifacts are planned to be licensed under various permissive licenses:
+
+Software source code: `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0.html>`_
+
+Model parameters, weights, and metadata: `CDLA-Permissive 2.0 License <https://cdla.dev/permissive-2-0/>`_
+
+Please see the respective license files for full details.
+
+Contact
+-------
+
+For questions, suggestions, or discussions, please:
+
+- Open an issue in this repository
+- Join our community `Discord server <https://discord.gg/vANKjzDDkQ>`_
+
+We look forward to your participation in the Open Model Initiative!

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,0 +1,36 @@
+:: SPDX-License-Identifier: Apache-2.0
+
+
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for building Open Model Initiative Data Repository documentation with Sphinx
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Please ensure Sphinx is installed.
+	echo.Set the SPHINXBUILD environment variable to the full path of the 'sphinx-build' executable.
+	echo.Or add the Sphinx directory to your PATH.
+	echo.
+	echo.Download Sphinx from https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd


### PR DESCRIPTION

FIX #154 

<!--- pyml disable-next-line no-emphasis-as-heading -->
- Adds documentation workflow to build static site and serve on gh-pages. 
- Mirror readme to index to start. Will create an additional PR to fill out content once the action is in main.
- Adds sphinx builder