### PR TITLE
Call recursive mkdir on image moderation access to ensure folders are made if they don't already exist

### DIFF
--- a/modules/odr_frontend/src/routes/+page.server.ts
+++ b/modules/odr_frontend/src/routes/+page.server.ts
@@ -121,7 +121,6 @@ export const actions = {
 			await mkdir(REJECTED_DIR, { recursive: true });
 			await mkdir(FLAGGED_DIR, { recursive: true });
 
-
 			if (process.env.NODE_ENV === 'production') {
 			  	// S3 upload for production
 				if (!s3Client) {


### PR DESCRIPTION
Closes #156 

Used `sudo rm -rf ./uploads/*` to remove the local development image folders, then navigate to the admin image moderation page without performing any image uploads.

Smooths out first time setup for local development to ensure if someone visits the image moderation page before they upload any HDR images, they do not get an error. 


Also fixes indentation of bottom two functions, only functional change is the new mkdir calls mirroring those called during image upload.