### PR TITLE
Add initial jsonl caption upload

### DIFF
--- a/modules/odr_frontend/src/lib/components/HDRUpload.svelte
+++ b/modules/odr_frontend/src/lib/components/HDRUpload.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+    import UploadIcon from '$lib/icons/UploadIcon.svelte';
+    import { FileDropzone } from '@skeletonlabs/skeleton';
+
+    export let user: any;
+
+    const acceptedFileTypes: Array<string> = ['.dng'];
+    let uploadStatus: string = '';
+    let uploadProgress: number = 0;
+    let files: FileList;
+    let errorArray: string[] = [];
+
+    $: selectedFiles = files ? Array.from(files) : [];
+
+    async function uploadFiles() {
+		const totalFiles = selectedFiles.length;
+		let completedUploads = 0;
+
+		for (const file of selectedFiles) {
+			if (acceptedFileTypes.some(type => file.name.endsWith(type))) {
+				uploadStatus = `Uploading ${file.name}...`;
+
+				const formData = new FormData();
+				formData.append('file', file);
+				formData.append('userId', user?.id ?? '');
+
+				try {
+					const response = await fetch('?/uploadHDR', {
+						method: 'POST',
+						body: formData
+					});
+
+					if (response.ok) {
+						const result = await response.json();
+						if (result.type === 'success') {
+							const data = JSON.parse(result.data);
+							const isSuccess = data[1];
+							const message = data[2];
+
+							if (isSuccess) {
+								uploadStatus = `${file.name} uploaded successfully`;
+							} else {
+								errorArray.push(`Failed to upload ${file.name}: ${message}`);
+							}
+						} else {
+							errorArray.push(`Failed to upload ${file.name}: Unexpected response type`);
+						}
+					} else {
+						errorArray.push(`Failed to upload ${file.name}: ${response.statusText || 'Unknown error'}`);
+					}
+				} catch (error: unknown) {
+					console.error('Error uploading file:', error);
+					if (error instanceof Error) {
+						errorArray.push(`Error uploading ${file.name}: ${error.message}`);
+					} else {
+						errorArray.push(`Error uploading ${file.name}: Unknown error`);
+					}
+				}
+
+				completedUploads++;
+				uploadProgress = Math.round((completedUploads / totalFiles) * 100);
+
+			} else {
+				errorArray.push(`Invalid file type: ${file.name}`);
+			}
+		}
+
+		if (errorArray.length === 0) {
+			uploadStatus = 'All files uploaded successfully';
+		} else {
+			uploadStatus = `Uploaded with ${errorArray.length} error${errorArray.length > 1 ? 's' : ''}`;
+		}
+
+		files = new DataTransfer().files
+	}
+</script>
+
+<div class="card variant-filled-surface">
+    <FileDropzone
+        class="container h-3/4 mx-auto"
+        name="files"
+        bind:files
+        accept={acceptedFileTypes.join(',')}
+        multiple
+    >
+        <svelte:fragment slot="lead">
+            <figure class="flex items-center justify-center">
+                <UploadIcon />
+            </figure>
+        </svelte:fragment>
+        <svelte:fragment slot="message">
+            {selectedFiles.length > 0 ? `${selectedFiles.length} file(s) selected` : 'Upload Images'}
+        </svelte:fragment>
+        <svelte:fragment slot="meta">Currently only accepting RAW images in .DNG</svelte:fragment>
+    </FileDropzone>
+    <div class="grid place-items-center mt-4">
+        <button on:click={uploadFiles} class="mt-4 btn btn-sm variant-outline-primary" disabled={selectedFiles.length === 0}>
+            Upload {selectedFiles.length} file(s)
+        </button>
+    </div>
+    {#if uploadStatus}
+    <div class="grid place-items-center mt-4">
+        <div class="w-full max-w-md shadow-md rounded-lg overflow-hidden">
+            <div class="p-4">
+                <div class="grid place-items-center">
+                    <p class="text-lg font-semibold mb-2">{uploadStatus}</p>
+                </div>
+                {#if uploadProgress > 0 && uploadProgress < 100}
+                    <progress value={uploadProgress} max="100" class="w-full"></progress>
+                    <p class="text-sm text-gray-600 mt-1">{uploadProgress}% complete</p>
+                {/if}
+                {#if errorArray.length > 0}
+                    <div class="grid place-items-center mt-4 max-h-40 overflow-y-auto">
+                        <p class="text-sm font-semibold mb-1">Errors:</p>
+                        <ul class="text-sm text-red-600">
+                            {#each errorArray as error}
+                                <li class="mb-1">{error}</li>
+                            {/each}
+                        </ul>
+                    </div>
+                {/if}
+            </div>
+        </div>
+    </div>
+    {/if}
+</div>

--- a/modules/odr_frontend/src/lib/components/JSONLUpload.svelte
+++ b/modules/odr_frontend/src/lib/components/JSONLUpload.svelte
@@ -89,9 +89,9 @@
         </figure>
       </svelte:fragment>
       <svelte:fragment slot="message">
-        {selectedFiles.length > 0 ? `${selectedFiles.length} file(s) selected` : 'Upload JSONL Files'}
+        {selectedFiles.length > 0 ? `${selectedFiles.length} file(s) selected` : 'Upload Annotation Files'}
       </svelte:fragment>
-      <svelte:fragment slot="meta">Currently only accepting .JSONL files</svelte:fragment>
+      <svelte:fragment slot="meta">Currently only accepting .JSONL files from graphcap</svelte:fragment>
     </FileDropzone>
     <div class="grid place-items-center mt-4">
         <button on:click={uploadFiles} class="mt-4 btn btn-sm variant-outline-primary" disabled={selectedFiles.length === 0}>

--- a/modules/odr_frontend/src/lib/components/JSONLUpload.svelte
+++ b/modules/odr_frontend/src/lib/components/JSONLUpload.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+    import UploadIcon from '$lib/icons/UploadIcon.svelte';
+    import { FileDropzone } from '@skeletonlabs/skeleton';
+
+    export let user: any;
+
+    const acceptedFileTypes: Array<string> = ['.jsonl'];
+    let uploadStatus: string = '';
+    let uploadProgress: number = 0;
+    let files: FileList;
+    let errorArray: string[] = [];
+
+    $: selectedFiles = files ? Array.from(files) : [];
+
+    async function uploadFiles() {
+        const totalFiles = selectedFiles.length;
+		let completedUploads = 0;
+
+		for (const file of selectedFiles) {
+			if (acceptedFileTypes.some(type => file.name.endsWith(type))) {
+				uploadStatus = `Uploading ${file.name}...`;
+
+				const formData = new FormData();
+				formData.append('file', file);
+				formData.append('userId', user?.id ?? '');
+
+				try {
+					const response = await fetch('?/uploadJSONL', {
+						method: 'POST',
+						body: formData
+					});
+
+					if (response.ok) {
+						const result = await response.json();
+						if (result.type === 'success') {
+							const data = JSON.parse(result.data);
+							const isSuccess = data[1];
+							const message = data[2];
+
+							if (isSuccess) {
+								uploadStatus = `${file.name} uploaded successfully`;
+							} else {
+								errorArray.push(`Failed to upload ${file.name}: ${message}`);
+							}
+						} else {
+							errorArray.push(`Failed to upload ${file.name}: Unexpected response type`);
+						}
+					} else {
+						errorArray.push(`Failed to upload ${file.name}: ${response.statusText || 'Unknown error'}`);
+					}
+				} catch (error: unknown) {
+					console.error('Error uploading file:', error);
+					if (error instanceof Error) {
+						errorArray.push(`Error uploading ${file.name}: ${error.message}`);
+					} else {
+						errorArray.push(`Error uploading ${file.name}: Unknown error`);
+					}
+				}
+
+				completedUploads++;
+				uploadProgress = Math.round((completedUploads / totalFiles) * 100);
+
+			} else {
+				errorArray.push(`Invalid file type: ${file.name}`);
+			}
+		}
+
+		if (errorArray.length === 0) {
+			uploadStatus = 'All files uploaded successfully';
+		} else {
+			uploadStatus = `Uploaded with ${errorArray.length} error${errorArray.length > 1 ? 's' : ''}`;
+		}
+
+		files = new DataTransfer().files
+    }
+  </script>
+
+  <div class="card variant-filled-surface">
+    <FileDropzone
+      class="container h-3/4 mx-auto"
+      name="files"
+      bind:files
+      accept={acceptedFileTypes.join(',')}
+      multiple
+    >
+      <svelte:fragment slot="lead">
+        <figure class="flex items-center justify-center">
+          <UploadIcon />
+        </figure>
+      </svelte:fragment>
+      <svelte:fragment slot="message">
+        {selectedFiles.length > 0 ? `${selectedFiles.length} file(s) selected` : 'Upload JSONL Files'}
+      </svelte:fragment>
+      <svelte:fragment slot="meta">Currently only accepting .JSONL files</svelte:fragment>
+    </FileDropzone>
+    <div class="grid place-items-center mt-4">
+        <button on:click={uploadFiles} class="mt-4 btn btn-sm variant-outline-primary" disabled={selectedFiles.length === 0}>
+            Upload {selectedFiles.length} file(s)
+        </button>
+    </div>
+    {#if uploadStatus}
+    <div class="grid place-items-center mt-4">
+        <div class="w-full max-w-md shadow-md rounded-lg overflow-hidden">
+            <div class="p-4">
+                <div class="grid place-items-center">
+                    <p class="text-lg font-semibold mb-2">{uploadStatus}</p>
+                </div>
+                {#if uploadProgress > 0 && uploadProgress < 100}
+                    <progress value={uploadProgress} max="100" class="w-full"></progress>
+                    <p class="text-sm text-gray-600 mt-1">{uploadProgress}% complete</p>
+                {/if}
+                {#if errorArray.length > 0}
+                    <div class="grid place-items-center mt-4 max-h-40 overflow-y-auto">
+                        <p class="text-sm font-semibold mb-1">Errors:</p>
+                        <ul class="text-sm text-red-600">
+                            {#each errorArray as error}
+                                <li class="mb-1">{error}</li>
+                            {/each}
+                        </ul>
+                    </div>
+                {/if}
+            </div>
+        </div>
+    </div>
+    {/if}
+  </div>

--- a/modules/odr_frontend/src/routes/+page.server.ts
+++ b/modules/odr_frontend/src/routes/+page.server.ts
@@ -235,8 +235,8 @@ export const actions = {
                 width: 0, // Need image to calculate
                 height: 0, // Need image to calculate
                 url: [], // S3 URL?
-                format: fileExtension,
-                size: file.size,
+                format: fileExtension, // This is currently jsonl for all images.
+                size: file.size, // This is currently the jsonL size without the image.
                 status: "pending",
                 license: "CDLA-Permissive-2.0",
                 license_url: "https://cdla.dev/permissive-2-0/",

--- a/modules/odr_frontend/src/routes/+page.svelte
+++ b/modules/odr_frontend/src/routes/+page.svelte
@@ -1,81 +1,10 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import UploadIcon from '$lib/icons/UploadIcon.svelte';
-	import { FileDropzone } from '@skeletonlabs/skeleton';
+	import HDRUpload from '$lib/components/HDRUpload.svelte';
+  	import JSONLUpload from '$lib/components/JSONLUpload.svelte';
 
 	$: featureToggles = $page.data.featureToggles;
 	$: user = $page.data.session?.user;
-
-	const acceptedFileTypes:Array<string> = ['.dng'];
-	let uploadStatus:string = '';
-	let uploadProgress: number = 0;
-	let files: FileList;
-
-	let errorArray: string[] = [];
-
-	$: selectedFiles = files ? Array.from(files) : [];
-
-	async function uploadFiles() {
-		const totalFiles = selectedFiles.length;
-		let completedUploads = 0;
-
-		for (const file of selectedFiles) {
-			if (acceptedFileTypes.some(type => file.name.endsWith(type))) {
-				uploadStatus = `Uploading ${file.name}...`;
-
-				const formData = new FormData();
-				formData.append('file', file);
-				formData.append('userId', user?.id ?? '');
-
-				try {
-					const response = await fetch('?/upload', {
-						method: 'POST',
-						body: formData
-					});
-
-					if (response.ok) {
-						const result = await response.json();
-						if (result.type === 'success') {
-							const data = JSON.parse(result.data);
-							const isSuccess = data[1];
-							const message = data[2];
-
-							if (isSuccess) {
-								uploadStatus = `${file.name} uploaded successfully`;
-							} else {
-								errorArray.push(`Failed to upload ${file.name}: ${message}`);
-							}
-						} else {
-							errorArray.push(`Failed to upload ${file.name}: Unexpected response type`);
-						}
-					} else {
-						errorArray.push(`Failed to upload ${file.name}: ${response.statusText || 'Unknown error'}`);
-					}
-				} catch (error: unknown) {
-					console.error('Error uploading file:', error);
-					if (error instanceof Error) {
-						errorArray.push(`Error uploading ${file.name}: ${error.message}`);
-					} else {
-						errorArray.push(`Error uploading ${file.name}: Unknown error`);
-					}
-				}
-
-				completedUploads++;
-				uploadProgress = Math.round((completedUploads / totalFiles) * 100);
-
-			} else {
-				errorArray.push(`Invalid file type: ${file.name}`);
-			}
-		}
-
-		if (errorArray.length === 0) {
-			uploadStatus = 'All files uploaded successfully';
-		} else {
-			uploadStatus = `Uploaded with ${errorArray.length} error${errorArray.length > 1 ? 's' : ''}`;
-		}
-
-		files = new DataTransfer().files
-	}
 </script>
 
 <svelte:head>
@@ -85,56 +14,12 @@
 <main class="space-y-4">
 	<div class="container h-full mx-auto grid grid-cols-2 gap-4">
 		{#if featureToggles['HDR Image Upload']}
-			<div class="card variant-filled-surface">
-				<FileDropzone
-					class="container h-3/4 mx-auto"
-					name="files"
-					bind:files
-					accept={acceptedFileTypes.join(',')}
-					multiple
-				>
-					<svelte:fragment slot="lead">
-						<figure class="flex items-center justify-center">
-							<UploadIcon />
-						</figure>
-					</svelte:fragment>
-					<svelte:fragment slot="message">
-						{selectedFiles.length > 0 ? `${selectedFiles.length} file(s) selected` : 'Upload Images'}
-					</svelte:fragment>
-					<svelte:fragment slot="meta">Currently only accepting RAW images in .DNG</svelte:fragment>
-				</FileDropzone>
-				<div class="grid place-items-center mt-4">
-					<button on:click={uploadFiles} class="mt-4 btn btn-sm variant-outline-primary" disabled={selectedFiles.length === 0}>
-						Upload {selectedFiles.length} file(s)
-					</button>
-				</div>
-				{#if uploadStatus}
-				<div class="grid place-items-center mt-4">
-					<div class="w-full max-w-md shadow-md rounded-lg overflow-hidden">
-						<div class="p-4">
-							<div class="grid place-items-center">
-								<p class="text-lg font-semibold mb-2">{uploadStatus}</p>
-							</div>
-							{#if uploadProgress > 0 && uploadProgress < 100}
-								<progress value={uploadProgress} max="100" class="w-full"></progress>
-								<p class="text-sm text-gray-600 mt-1">{uploadProgress}% complete</p>
-							{/if}
-							{#if errorArray.length > 0}
-								<div class="grid place-items-center mt-4 max-h-40 overflow-y-auto">
-									<p class="text-sm font-semibold mb-1">Errors:</p>
-									<ul class="text-sm text-red-600">
-										{#each errorArray as error}
-											<li class="mb-1">{error}</li>
-										{/each}
-									</ul>
-								</div>
-							{/if}
-						</div>
-					</div>
-				</div>
-				{/if}
-			</div>
+			<HDRUpload {user} />
 		{/if}
+
+		<!-- {#if featureToggles['JSONL Upload']} -->
+			<JSONLUpload {user} />
+		<!-- {/if} -->
 
 		<!-- <div class="card variant-filled-surface">
 			<header class="card-header text-lg font-bold text-primary-200">


### PR DESCRIPTION
# Description

Add an initial process for uploading caption files from graphcap in jsonl to the content and annotation tables.
Some progress on #150 , some progress on #124 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD updates
- [ ] Other (please describe):

## How Has This Been Tested?

Tested both the HDR and JSONL uploads to ensure they processed expected files correctly.

Used the fastAPI OpenAPI docs page to do gets for both the content and annotation tables and both showed the expected results for this work so far.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added or updated tests that prove my fix is effective or my feature works

## Additional Context

This is the first step here and more work and changes will be needed to see this over the line, but it is hopefully in a better starting position now.
