### PR TITLE
Fix issue with div covering home link and update playwright test with new locator

### DIFF
--- a/modules/odr_frontend/playwright.config.ts
+++ b/modules/odr_frontend/playwright.config.ts
@@ -4,6 +4,7 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
 	testDir: 'tests',
 	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 1 : 0,
 	testMatch: /(.+\.)?(test|spec)\.[jt]s/,
 	use: {
 		baseURL: 'http://localhost:5173',

--- a/modules/odr_frontend/src/app.postcss
+++ b/modules/odr_frontend/src/app.postcss
@@ -14,3 +14,11 @@ body {
 	src: url('/fonts/SpaceGrotesk.ttf');
 	font-display: swap;
 }
+
+.passthrough-div {
+  pointer-events: none;
+}
+
+.passthrough-div * {
+  pointer-events: auto;
+}

--- a/modules/odr_frontend/src/routes/auth/+page.svelte
+++ b/modules/odr_frontend/src/routes/auth/+page.svelte
@@ -16,7 +16,7 @@
 	});
 </script>
 
-<div class="flex flex-col items-center justify-center -mt-16">
+<div class="flex flex-col items-center justify-center -mt-16 passthrough-div">
 	<h1 class="text-4xl font-bold mb-8 text-center">Data Pipeline Application</h1>
 
 	<main class="flex flex-col w-1/5 min-w-[400px] bg-surface-500 p-8">

--- a/modules/odr_frontend/tests/test.ts
+++ b/modules/odr_frontend/tests/test.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 
 test('Auth page has expected home link', async ({ page }) => {
 	await page.goto('/');
-	await expect(page.getByRole('link', { name: 'OMI DATA PIPELINE' })).toBeVisible();
+	await expect(page.getByRole('link', { name: 'Open Model Initiative' })).toBeVisible();
 });
 
 test('Auth page has expected sign in options', async ({ page }) => {

--- a/run-playwright.sh
+++ b/run-playwright.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 set -e
 
-task dev &
+task dev:migrate &
 echo "Waiting for services to start..."
 
 # Maximum wait time in seconds


### PR DESCRIPTION

# Description

Fix the issue with the failing playwright test. 
Fixes #188 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD updates
- [ ] Other (please describe):

## How Has This Been Tested?

Manually clicked the omi logo and ensured it linked back to '/' correctly now without being blocked by overlay.

Also ran the Playwright test which was failing locally and it now passes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added or updated tests that prove my fix is effective or my feature works

