### PR TITLE
Fix frontend directory name

### DIFF
--- a/doc/contributing/getting_started/project_setup.rst
+++ b/doc/contributing/getting_started/project_setup.rst
@@ -45,7 +45,7 @@ Along with installing the necessary components, this will copy the ``.env.templa
 You can update this file if you'd like to change any of the default values for your development environment. You will at minimum need to provide a valid ID and SECRET for at least one authentication method.
 See the following 'Setup an OAuth2 Test Application' section for information on how to set these up.
 
-You will also need to make matching updates in the frontends .env in ``./modules/frontend/.env``
+You will also need to make matching updates in the frontends .env in ``./modules/odr_frontend/.env``
 
 Setup an OAuth2 Test Application
 --------------------------------

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -13,10 +13,10 @@ if (Test-Path -Path ".env") {
 Copy-Item -Path ".env.template" -Destination ".env"
 
 # Check if the frontend .env file exists
-if (Test-Path -Path "./modules/frontend/.env") {
+if (Test-Path -Path "./modules/odr_frontend/.env") {
     $choice = Read-Host "The frontend .env file already exists. Do you want to replace it? (Y/N)"
     if ($choice -eq "Y" -or $choice -eq "y") {
-        Remove-Item -Path "./modules/frontend/.env"
+        Remove-Item -Path "./modules/odr_frontend/.env"
     } else {
         Write-Host "Keeping existing .env file. Exiting."
         exit
@@ -24,7 +24,7 @@ if (Test-Path -Path "./modules/frontend/.env") {
 }
 
 # Copy the frontend .env.template to .env
-Copy-Item -Path "./modules/frontend/.env.template" -Destination "./modules/frontend/.env"
+Copy-Item -Path "./modules/odr_frontend/.env.template" -Destination "./modules/odr_frontend/.env"
 
 # Ask user for root directory
 $rootDir = Read-Host "Please enter the root directory path"


### PR DESCRIPTION
# Description

/modules/frontend was renamed in parts of the code to /modules/odr_frontend
This changes the remaining files I found that referenced the old directory name.

## Type of Change

- [X ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD updates
- [ ] Other (please describe):

## How Has This Been Tested?

I was not able to run the project without this change and was able to with it.

## Checklist

- [ ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [ ] I have added or updated tests that prove my fix is effective or my feature works